### PR TITLE
Add LLM integration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ response = client.messages.create(
 | `ColumnSummary` | Structured result from column analysis |
 | `BudgetPlan` | Token budget allocation plan |
 
+## Examples
+
+See the [`examples/`](examples/) directory for runnable scripts:
+
+- **[with_claude.py](examples/with_claude.py)** — Analyze a DataFrame with Anthropic Claude
+- **[with_openai.py](examples/with_openai.py)** — Analyze a DataFrame with OpenAI GPT
+- **[compare_dataframes.py](examples/compare_dataframes.py)** — Year-over-year comparison
+- **[budget_tuning.py](examples/budget_tuning.py)** — See how budget affects output (no API key needed)
+- **[mcp_server.py](examples/mcp_server.py)** — Build an MCP tool that summarizes CSV files
+
 ## License
 
 MIT

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+# dfcontext Examples
+
+Practical examples showing how to use dfcontext with LLMs and data workflows.
+
+| Example | Description |
+|---------|-------------|
+| [with_claude.py](with_claude.py) | Analyze a DataFrame with Anthropic Claude |
+| [with_openai.py](with_openai.py) | Analyze a DataFrame with OpenAI GPT |
+| [compare_dataframes.py](compare_dataframes.py) | Compare two DataFrames (e.g. year-over-year) |
+| [budget_tuning.py](budget_tuning.py) | See how different token budgets affect output |
+| [mcp_server.py](mcp_server.py) | Build an MCP server tool that summarizes datasets |
+
+## Prerequisites
+
+```bash
+pip install dfcontext[all]
+
+# For LLM examples:
+pip install anthropic   # with_claude.py
+pip install openai      # with_openai.py
+pip install fastmcp     # mcp_server.py
+```

--- a/examples/budget_tuning.py
+++ b/examples/budget_tuning.py
@@ -1,0 +1,85 @@
+"""See how different token budgets affect dfcontext output.
+
+No API key required — this example runs locally and shows you
+what information is included at each budget level.
+
+Prerequisites:
+    pip install dfcontext[all]
+
+Usage:
+    python budget_tuning.py
+"""
+
+import numpy as np
+import pandas as pd
+
+from dfcontext import ContextConfig, count_tokens, to_context
+
+# --- Sample data ---
+np.random.seed(42)
+n = 10_000
+
+df = pd.DataFrame({
+    "region": np.random.choice(["East", "West", "North", "South", "Central"], n),
+    "product": np.random.choice(["Widget A", "Widget B", "Gadget X", "Gadget Y"], n),
+    "sales": np.random.exponential(1000, n).round(2),
+    "quantity": np.random.randint(1, 200, n),
+    "date": pd.date_range("2023-01-01", periods=n, freq="h"),
+    "is_return": np.random.choice([True, False], n, p=[0.07, 0.93]),
+})
+
+# --- Compare budgets ---
+budgets = [200, 500, 1000, 2000, 5000]
+
+for budget in budgets:
+    ctx = to_context(df, token_budget=budget)
+    actual_tokens = count_tokens(ctx)
+    lines = ctx.count("\n") + 1
+    has_stats = "Column statistics" in ctx
+    has_samples = "Sample rows" in ctx
+
+    print(f"Budget: {budget:>5} tokens")
+    print(f"  Actual:  {actual_tokens:>5} tokens, {lines:>3} lines")
+    print(f"  Stats:   {'yes' if has_stats else 'no'}")
+    print(f"  Samples: {'yes' if has_samples else 'no'}")
+    print()
+
+# --- Compare sections ---
+print("=" * 60)
+print("Schema only vs Full context")
+print("=" * 60)
+print()
+
+schema_only = to_context(
+    df,
+    token_budget=2000,
+    include_stats=False,
+    include_samples=False,
+)
+print(f"Schema only: {count_tokens(schema_only)} tokens")
+print(schema_only)
+print()
+
+stats_only = to_context(
+    df,
+    token_budget=2000,
+    include_schema=False,
+    include_samples=False,
+)
+print(f"Stats only: {count_tokens(stats_only)} tokens")
+print(stats_only)
+print()
+
+# --- Custom budget ratios ---
+print("=" * 60)
+print("Custom budget ratio: more stats, fewer samples")
+print("=" * 60)
+print()
+
+config = ContextConfig(
+    token_budget=1500,
+    budget_ratio={"schema": 0.10, "stats": 0.75, "samples": 0.15},
+)
+ctx = to_context(df, config=config)
+print(f"Custom ratio: {count_tokens(ctx)} tokens")
+print(ctx)

--- a/examples/compare_dataframes.py
+++ b/examples/compare_dataframes.py
@@ -1,0 +1,68 @@
+"""Compare two DataFrames side by side with dfcontext.
+
+A common use case: year-over-year comparison, A/B test results,
+or before/after analysis. Generate context for each DataFrame
+and let the LLM find the differences.
+
+Prerequisites:
+    pip install dfcontext[all] anthropic
+
+Usage:
+    export ANTHROPIC_API_KEY="your-key"
+    python compare_dataframes.py
+"""
+
+import anthropic
+import numpy as np
+import pandas as pd
+
+from dfcontext import count_tokens, to_context
+
+# --- Simulate 2023 vs 2024 sales data ---
+np.random.seed(42)
+
+df_2023 = pd.DataFrame({
+    "region": np.random.choice(["East", "West", "North", "South"], 20_000),
+    "sales": np.random.exponential(800, 20_000).round(2),
+    "quantity": np.random.randint(1, 80, 20_000),
+    "date": pd.date_range("2023-01-01", periods=20_000, freq="h"),
+})
+
+df_2024 = pd.DataFrame({
+    "region": np.random.choice(["East", "West", "North", "South"], 25_000),
+    "sales": np.random.exponential(1200, 25_000).round(2),  # Growth!
+    "quantity": np.random.randint(1, 120, 25_000),
+    "date": pd.date_range("2024-01-01", periods=25_000, freq="h"),
+})
+
+# --- Generate context for each (split the budget) ---
+# Use the same hint so both focus on comparable aspects
+hint = "sales volume and regional distribution"
+
+ctx_2023 = to_context(df_2023, token_budget=800, hint=hint)
+ctx_2024 = to_context(df_2024, token_budget=800, hint=hint)
+
+# --- Combine into a comparison prompt ---
+prompt = f"""## 2023 Data
+{ctx_2023}
+
+## 2024 Data
+{ctx_2024}
+
+Compare the two years. What changed? Identify growth areas and concerns."""
+
+print("=== Combined prompt length ===")
+print(f"{count_tokens(prompt)} tokens")
+print()
+
+# --- Send to Claude ---
+client = anthropic.Anthropic()
+
+response = client.messages.create(
+    model="claude-sonnet-4-20250514",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": prompt}],
+)
+
+print("=== Year-over-Year Analysis ===")
+print(response.content[0].text)

--- a/examples/mcp_server.py
+++ b/examples/mcp_server.py
@@ -1,0 +1,83 @@
+"""Build an MCP server tool that summarizes datasets with dfcontext.
+
+This creates a tool that any MCP client (Claude Desktop, etc.) can call
+to get an intelligent summary of a CSV file.
+
+Prerequisites:
+    pip install dfcontext[all] fastmcp
+
+Usage:
+    python mcp_server.py
+    # Then connect via an MCP client
+"""
+
+import pandas as pd
+from fastmcp import FastMCP
+
+from dfcontext import to_context
+
+mcp = FastMCP("DataAnalyzer")
+
+
+@mcp.tool()
+def describe_dataset(
+    file_path: str,
+    question: str = "",
+    token_budget: int = 2000,
+) -> str:
+    """Summarize a CSV dataset for LLM analysis.
+
+    Args:
+        file_path: Path to a CSV file.
+        question: Optional question to focus the summary on relevant columns.
+        token_budget: Maximum tokens for the summary (default 2000).
+
+    Returns:
+        A structured summary of the dataset.
+    """
+    df = pd.read_csv(file_path)
+
+    ctx = to_context(
+        df,
+        token_budget=token_budget,
+        hint=question if question else None,
+    )
+
+    if question:
+        return f"{ctx}\n\n(Focus: {question})"
+    return ctx
+
+
+@mcp.tool()
+def compare_datasets(
+    file_path_a: str,
+    file_path_b: str,
+    label_a: str = "Dataset A",
+    label_b: str = "Dataset B",
+    token_budget: int = 3000,
+) -> str:
+    """Compare two CSV datasets side by side.
+
+    Args:
+        file_path_a: Path to the first CSV file.
+        file_path_b: Path to the second CSV file.
+        label_a: Label for the first dataset.
+        label_b: Label for the second dataset.
+        token_budget: Total token budget (split between both datasets).
+
+    Returns:
+        A side-by-side summary of both datasets.
+    """
+    per_dataset = token_budget // 2
+
+    df_a = pd.read_csv(file_path_a)
+    df_b = pd.read_csv(file_path_b)
+
+    ctx_a = to_context(df_a, token_budget=per_dataset)
+    ctx_b = to_context(df_b, token_budget=per_dataset)
+
+    return f"## {label_a}\n{ctx_a}\n\n## {label_b}\n{ctx_b}"
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/examples/with_claude.py
+++ b/examples/with_claude.py
@@ -1,0 +1,76 @@
+"""Use dfcontext with Anthropic Claude.
+
+This example shows how to generate DataFrame context and pass it
+to Claude for analysis. The key idea: instead of dumping raw data,
+dfcontext gives Claude a compact but statistically rich summary.
+
+Prerequisites:
+    pip install dfcontext[all] anthropic
+
+Usage:
+    export ANTHROPIC_API_KEY="your-key"
+    python with_claude.py
+"""
+
+import anthropic
+import numpy as np
+import pandas as pd
+
+from dfcontext import to_context
+
+# --- 1. Prepare sample data ---
+np.random.seed(42)
+n = 50_000
+
+df = pd.DataFrame({
+    "region": np.random.choice(["East", "West", "North", "South"], n),
+    "product": np.random.choice(["Widget A", "Widget B", "Gadget X"], n),
+    "sales": np.random.exponential(1000, n).round(2),
+    "quantity": np.random.randint(1, 100, n),
+    "date": pd.date_range("2023-01-01", periods=n, freq="h"),
+    "is_return": np.random.choice([True, False], n, p=[0.06, 0.94]),
+})
+
+# --- 2. Generate context ---
+# Without dfcontext, df.to_string() would produce ~2M tokens.
+# With dfcontext, we get a rich summary in ~600 tokens.
+ctx = to_context(df, token_budget=1000, hint="regional sales performance")
+
+print("=== Generated Context ===")
+print(ctx)
+print()
+
+# --- 3. Send to Claude ---
+client = anthropic.Anthropic()
+
+question = (
+    "What are the key insights about regional sales "
+    "performance? Are there any notable patterns?"
+)
+
+response = client.messages.create(
+    model="claude-sonnet-4-20250514",
+    max_tokens=1024,
+    messages=[{
+        "role": "user",
+        "content": f"{ctx}\n\n{question}",
+    }],
+)
+
+print("=== Claude's Analysis ===")
+print(response.content[0].text)
+
+
+# --- Tips ---
+# 1. Use `hint` to focus on what you're analyzing:
+#    ctx = to_context(df, hint="return rate by product")
+#
+# 2. Adjust budget based on your needs:
+#    - 500 tokens: quick overview (schema + basic stats)
+#    - 2000 tokens: standard analysis (full stats + samples)
+#    - 5000 tokens: detailed analysis (everything + more samples)
+#
+# 3. For multi-turn conversations, generate context once and reuse:
+#    ctx = to_context(df, token_budget=2000)
+#    messages = [{"role": "user", "content": f"{ctx}\n\nFirst question..."}]
+#    # ... get response, then ask follow-ups without resending ctx

--- a/examples/with_openai.py
+++ b/examples/with_openai.py
@@ -1,0 +1,51 @@
+"""Use dfcontext with OpenAI GPT.
+
+Prerequisites:
+    pip install dfcontext[all] openai
+
+Usage:
+    export OPENAI_API_KEY="your-key"
+    python with_openai.py
+"""
+
+import numpy as np
+import pandas as pd
+from openai import OpenAI
+
+from dfcontext import to_context
+
+# --- Prepare data ---
+np.random.seed(42)
+df = pd.DataFrame({
+    "customer_id": range(10_000),
+    "age": np.random.normal(35, 12, 10_000).clip(18, 80).astype(int),
+    "plan": np.random.choice(["free", "basic", "premium"], 10_000, p=[0.6, 0.25, 0.15]),
+    "monthly_spend": np.random.exponential(50, 10_000).round(2),
+    "days_active": np.random.randint(1, 365, 10_000),
+    "churned": np.random.choice([True, False], 10_000, p=[0.15, 0.85]),
+})
+
+# --- Generate context with a churn-focused hint ---
+ctx = to_context(df, token_budget=1500, hint="churn prediction factors")
+
+print("=== Context ===")
+print(ctx)
+print()
+
+# --- Send to GPT ---
+client = OpenAI()
+
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{
+        "role": "user",
+        "content": (
+            f"{ctx}\n\n"
+            "Based on this data overview, what features seem most "
+            "relevant for predicting customer churn? Suggest a modeling approach."
+        ),
+    }],
+)
+
+print("=== GPT's Analysis ===")
+print(response.choices[0].message.content)


### PR DESCRIPTION
## Summary

Add practical, runnable example scripts showing how to use dfcontext with various LLM providers and workflows:

- **with_claude.py** — DataFrame analysis with Anthropic Claude
- **with_openai.py** — Customer churn analysis with OpenAI GPT
- **compare_dataframes.py** — Year-over-year comparison (two DataFrames → one prompt)
- **budget_tuning.py** — Token budget tuning guide (no API key required)
- **mcp_server.py** — MCP server tool for dataset summarization

Also adds an Examples section to README linking to all scripts.

Closes #19

## Test plan

- [x] `budget_tuning.py` runs successfully (no API key needed)
- [x] `uv run ruff check examples/` passes
- [x] All example scripts have clear docstrings and prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)