### PR TITLE
ci: Upgrade GitHub Actions to v5 (Node.js 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
         with:
-          file: coverage.xml
+          files: coverage.xml
 
   publish:
     needs: test


### PR DESCRIPTION
## Summary

Upgrade all GitHub Actions to v5 to resolve Node.js 20 deprecation warnings:
- `actions/checkout` v4 → v5
- `astral-sh/setup-uv` v4 → v5
- `codecov/codecov-action` v4 → v5

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)