### PR TITLE
ci: Bump astral-sh/setup-uv from v5 to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Build
         run: uv build
       - name: Publish to PyPI


### PR DESCRIPTION
## Summary

Bump astral-sh/setup-uv v5 → v7 (mirrors Dependabot #26, which cannot be merged via CLI due to workflow scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)