### PR TITLE
refactor: Expand ruff lint rules (D, PT, RUF)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,18 @@ line-length = 88
 src = ["src", "tests"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH"]
+select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH", "D", "PT", "RUF"]
+ignore = [
+    "D203",   # incompatible with D211
+    "D213",   # incompatible with D212
+    "D105",   # missing docstring in magic method (__post_init__ etc.)
+    "D107",   # missing docstring in __init__ (class docstring suffices)
+    "RUF001", # ambiguous unicode (× multiplication sign is intentional)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D"]         # No docstrings required in tests
+"examples/**" = ["D"]      # No docstrings required in examples
 
 [tool.mypy]
 python_version = "3.10"

--- a/src/dfcontext/__init__.py
+++ b/src/dfcontext/__init__.py
@@ -7,10 +7,10 @@ from dfcontext.config import ContextConfig
 from dfcontext.core import analyze_columns, count_tokens, to_context
 
 __all__ = [
-    "__version__",
     "BudgetPlan",
     "ColumnSummary",
     "ContextConfig",
+    "__version__",
     "analyze_columns",
     "count_tokens",
     "to_context",

--- a/src/dfcontext/analyzers/base.py
+++ b/src/dfcontext/analyzers/base.py
@@ -35,6 +35,7 @@ class ColumnSummary:
         Representative sample values.
     distribution_sketch : str or None
         Mini histogram for numeric columns.
+
     """
 
     name: str
@@ -66,6 +67,7 @@ class BaseAnalyzer(ABC):
         Returns
         -------
         ColumnSummary
+
         """
 
     def _base_info(
@@ -96,6 +98,7 @@ def classify_column(
     Returns
     -------
     ColumnType
+
     """
     import pandas as pd
 

--- a/src/dfcontext/analyzers/boolean.py
+++ b/src/dfcontext/analyzers/boolean.py
@@ -26,6 +26,7 @@ class BooleanAnalyzer(BaseAnalyzer):
         Returns
         -------
         ColumnSummary
+
         """
         info = self._base_info(series, "boolean")
         valid = series.dropna()

--- a/src/dfcontext/analyzers/categorical.py
+++ b/src/dfcontext/analyzers/categorical.py
@@ -26,6 +26,7 @@ class CategoricalAnalyzer(BaseAnalyzer):
         Returns
         -------
         ColumnSummary
+
         """
         info = self._base_info(series, "categorical")
         valid = series.dropna()

--- a/src/dfcontext/analyzers/datetime.py
+++ b/src/dfcontext/analyzers/datetime.py
@@ -26,6 +26,7 @@ class DatetimeAnalyzer(BaseAnalyzer):
         Returns
         -------
         ColumnSummary
+
         """
         info = self._base_info(series, "datetime")
         valid = series.dropna()
@@ -59,6 +60,7 @@ def _estimate_granularity(series: pd.Series) -> str | None:
     -------
     str or None
         Estimated granularity label, or ``None`` if undetermined.
+
     """
     if len(series) < 2:
         return None

--- a/src/dfcontext/analyzers/numeric.py
+++ b/src/dfcontext/analyzers/numeric.py
@@ -30,6 +30,7 @@ class NumericAnalyzer(BaseAnalyzer):
         Returns
         -------
         ColumnSummary
+
         """
         info = self._base_info(series, "numeric")
         valid = series.dropna()
@@ -81,6 +82,7 @@ def _mini_histogram(series: pd.Series, bins: int = 8) -> str:
     -------
     str
         A string like ``"▁▃▇█▅▂▁▁"``.
+
     """
     if len(series) == 0:
         return ""

--- a/src/dfcontext/analyzers/text.py
+++ b/src/dfcontext/analyzers/text.py
@@ -33,6 +33,7 @@ class TextAnalyzer(BaseAnalyzer):
         Returns
         -------
         ColumnSummary
+
         """
         info = self._base_info(series, "text")
         valid = series.dropna().astype(str)
@@ -76,6 +77,7 @@ def _detect_patterns(
     -------
     list[str]
         Names of detected patterns.
+
     """
     sample = series.head(sample_size)
     detected: list[str] = []

--- a/src/dfcontext/budget.py
+++ b/src/dfcontext/budget.py
@@ -26,6 +26,7 @@ class BudgetPlan:
         Tokens allocated to sample rows.
     total_budget : int
         Total token budget.
+
     """
 
     schema_budget: int
@@ -41,6 +42,7 @@ class TokenBudgetAllocator:
     ----------
     budget_ratio : dict[str, float]
         Ratios for schema, stats, and samples sections.
+
     """
 
     def __init__(
@@ -82,6 +84,7 @@ class TokenBudgetAllocator:
         Returns
         -------
         BudgetPlan
+
         """
         # Compute active ratios
         active: dict[str, float] = {}
@@ -148,6 +151,7 @@ def _distribute_column_budget(
     -------
     dict[str, int]
         Budget per column.
+
     """
     if not columns:
         return {}

--- a/src/dfcontext/config.py
+++ b/src/dfcontext/config.py
@@ -38,6 +38,7 @@ class ContextConfig:
         tiktoken encoding name.
     budget_ratio : dict[str, float]
         Token budget allocation ratios for schema, stats, and samples.
+
     """
 
     token_budget: int = 2000

--- a/src/dfcontext/core.py
+++ b/src/dfcontext/core.py
@@ -41,7 +41,7 @@ _FORMATTERS: dict[str, BaseFormatter] = {
 def to_context(
     df: pd.DataFrame,
     token_budget: int = 2000,
-    format: Literal["markdown", "plain", "yaml"] = "markdown",  # noqa: A002
+    format: Literal["markdown", "plain", "yaml"] = "markdown",
     hint: str | None = None,
     include_schema: bool = True,
     include_stats: bool = True,
@@ -82,6 +82,7 @@ def to_context(
     -------
     str
         Context string for use with an LLM.
+
     """
     if config is not None:
         cfg = config
@@ -172,6 +173,7 @@ def analyze_columns(
     -------
     dict[str, ColumnSummary]
         Column name to summary mapping.
+
     """
     cols = columns or list(df.columns)
     result: dict[str, ColumnSummary] = {}
@@ -198,6 +200,7 @@ def count_tokens(
     -------
     int
         Token count.
+
     """
     tc = TokenCounter(tokenizer)
     return tc.count(text)

--- a/src/dfcontext/hints.py
+++ b/src/dfcontext/hints.py
@@ -28,6 +28,7 @@ def compute_hint_relevance(
     -------
     float
         Relevance score between 0.0 and 1.0.
+
     """
     score = 0.0
     hint_lower = hint.lower()

--- a/src/dfcontext/sampler.py
+++ b/src/dfcontext/sampler.py
@@ -38,6 +38,7 @@ class RepresentativeSampler:
         -------
         pd.DataFrame
             A subset of representative rows.
+
         """
         if df.empty or max_rows <= 0:
             return pd_runtime.DataFrame(df.head(0))

--- a/src/dfcontext/tokenizer.py
+++ b/src/dfcontext/tokenizer.py
@@ -18,6 +18,7 @@ class TokenCounter:
         tiktoken encoding name (e.g. "cl100k_base"). Used only when
         tiktoken is installed; otherwise falls back to character-based
         estimation.
+
     """
 
     def __init__(self, encoding_name: str = "cl100k_base") -> None:
@@ -30,7 +31,7 @@ class TokenCounter:
 
             return tiktoken.get_encoding(self._encoding_name)
         except ImportError:
-            global _FALLBACK_WARNED  # noqa: PLW0603
+            global _FALLBACK_WARNED
             if not _FALLBACK_WARNED:
                 warnings.warn(
                     "tiktoken is not installed. Token counts will be estimated "
@@ -54,6 +55,7 @@ class TokenCounter:
         -------
         int
             Token count (exact with tiktoken, estimated otherwise).
+
         """
         if not text:
             return 0
@@ -74,6 +76,7 @@ class TokenCounter:
         Returns
         -------
         bool
+
         """
         return self.count(text) <= budget
 
@@ -91,6 +94,7 @@ class TokenCounter:
         -------
         str
             The (possibly truncated) text.
+
         """
         if budget <= 0:
             return ""


### PR DESCRIPTION
## Summary

- Add `D` (docstrings), `PT` (pytest), `RUF` (ruff-specific) lint rules
- Fix 28 auto-fixable violations (docstring blank lines, unsorted `__all__`, unused noqa)
- Configure ignore rules for intentional patterns
- Exempt tests/ and examples/ from docstring requirements

Closes #35

## Test plan

- [x] `uv run ruff check src/ tests/ examples/` passes
- [x] `uv run mypy src/` passes
- [x] 138 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)