### PR TITLE
refactor: Standardize pandas import pattern

### DIFF
--- a/src/dfcontext/analyzers/datetime.py
+++ b/src/dfcontext/analyzers/datetime.py
@@ -71,9 +71,9 @@ def _estimate_granularity(series: pd.Series) -> str | None:
     if len(diffs) == 0:
         return None
 
-    import pandas as pd_mod
+    import pandas as pd
 
-    median_diff = pd_mod.Timedelta(diffs.median())
+    median_diff = pd.Timedelta(diffs.median())
     seconds = median_diff.total_seconds()
 
     if seconds == 0:

--- a/src/dfcontext/sampler.py
+++ b/src/dfcontext/sampler.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pandas as pd_runtime
-
 if TYPE_CHECKING:
     import pandas as pd
 
@@ -40,20 +38,19 @@ class RepresentativeSampler:
             A subset of representative rows.
 
         """
+        import pandas as pd
+
         if df.empty or max_rows <= 0:
-            return pd_runtime.DataFrame(df.head(0))
+            return pd.DataFrame(df.head(0))
 
         if len(df) <= max_rows:
             return df
 
-        # Try stratified sampling on categorical columns
         cat_cols = [
             c
             for c in df.columns
-            if pd_runtime.api.types.is_object_dtype(df[c])
-            or isinstance(
-                df[c].dtype, pd_runtime.CategoricalDtype
-            )
+            if pd.api.types.is_object_dtype(df[c])
+            or isinstance(df[c].dtype, pd.CategoricalDtype)
         ]
 
         if cat_cols:
@@ -61,11 +58,10 @@ class RepresentativeSampler:
                 df, cat_cols[0], max_rows, seed
             )
 
-        # Numeric-only: pick diverse rows
         num_cols = [
             c
             for c in df.columns
-            if pd_runtime.api.types.is_numeric_dtype(df[c])
+            if pd.api.types.is_numeric_dtype(df[c])
         ]
 
         if num_cols:
@@ -73,7 +69,6 @@ class RepresentativeSampler:
                 df, num_cols[0], max_rows, seed
             )
 
-        # Fallback: evenly spaced
         return _evenly_spaced(df, max_rows)
 
 
@@ -84,11 +79,13 @@ def _stratified_sample(
     seed: int,
 ) -> pd.DataFrame:
     """Sample rows stratified by a categorical column."""
+    import pandas as pd
+
     groups = df.groupby(col, observed=True)
     n_groups = groups.ngroups
 
     if n_groups == 0:
-        return pd_runtime.DataFrame(df.head(max_rows))
+        return pd.DataFrame(df.head(max_rows))
 
     per_group = max(1, max_rows // n_groups)
     samples = []
@@ -96,8 +93,8 @@ def _stratified_sample(
         n = min(per_group, len(group))
         samples.append(group.sample(n=n, random_state=seed))
 
-    result = pd_runtime.concat(samples)
-    return pd_runtime.DataFrame(result.head(max_rows))
+    result = pd.concat(samples)
+    return pd.DataFrame(result.head(max_rows))
 
 
 def _numeric_diverse_sample(
@@ -107,15 +104,15 @@ def _numeric_diverse_sample(
     seed: int,
 ) -> pd.DataFrame:
     """Sample rows near min, max, median, plus random."""
+    import pandas as pd
+
     sorted_df = df.sort_values(col).reset_index(drop=True)
     pos_indices: set[int] = set()
 
-    # Min, max, median (positional)
     pos_indices.add(0)
     pos_indices.add(len(sorted_df) - 1)
     pos_indices.add(len(sorted_df) // 2)
 
-    # Fill remaining with random
     remaining = max_rows - len(pos_indices)
     if remaining > 0:
         pool = [
@@ -128,7 +125,7 @@ def _numeric_diverse_sample(
             )
             pos_indices.update(rng.index.tolist())
 
-    return pd_runtime.DataFrame(
+    return pd.DataFrame(
         sorted_df.iloc[sorted(pos_indices)].head(max_rows)
     )
 
@@ -138,6 +135,7 @@ def _evenly_spaced(
 ) -> pd.DataFrame:
     """Select evenly spaced rows."""
     import numpy as np
+    import pandas as pd
 
     idx = np.linspace(0, len(df) - 1, num=max_rows, dtype=int)
-    return pd_runtime.DataFrame(df.iloc[idx])
+    return pd.DataFrame(df.iloc[idx])


### PR DESCRIPTION
## Summary

Replace inconsistent `pd_runtime` / `pd_mod` aliases with `import pandas as pd` inside functions consistently.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)