### PR TITLE
fix: Dynamic min-per-column budget to prevent overflow

### DIFF
--- a/src/dfcontext/budget.py
+++ b/src/dfcontext/budget.py
@@ -191,10 +191,14 @@ def _distribute_column_budget(
         per_col = stats_budget // max(len(columns), 1)
         return {col: per_col for col in columns}
 
+    # Dynamic minimum: ensure total doesn't exceed stats_budget
+    min_per_col = min(10, stats_budget // max(len(columns), 1))
+
     result: dict[str, int] = {}
     for col in columns:
         result[col] = max(
-            10, int(stats_budget * weights[col] / total_weight)
+            min_per_col,
+            int(stats_budget * weights[col] / total_weight),
         )
 
     return result

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -106,3 +106,15 @@ class TestTokenBudgetAllocator:
         plan = allocator.allocate(df, total_budget=1000)
 
         assert plan.schema_budget == 500
+
+    def test_many_columns_low_budget_no_overflow(self) -> None:
+        df = pd.DataFrame({f"c{i}": [1] for i in range(50)})
+        allocator = TokenBudgetAllocator()
+        plan = allocator.allocate(
+            df,
+            total_budget=100,
+            include_schema=False,
+            include_samples=False,
+        )
+        total_col_budget = sum(plan.column_budgets.values())
+        assert total_col_budget <= 100


### PR DESCRIPTION
## Summary

Fix edge case where 50 columns × min 10 tokens = 500 tokens could exceed a small stats_budget. Minimum is now dynamically calculated as `min(10, stats_budget // num_columns)`.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)