### PR TITLE
feat: Add column_priority for direct weight override

### DIFF
--- a/src/dfcontext/budget.py
+++ b/src/dfcontext/budget.py
@@ -65,6 +65,7 @@ class TokenBudgetAllocator:
         include_schema: bool = True,
         include_stats: bool = True,
         include_samples: bool = True,
+        column_priority: dict[str, float] | None = None,
     ) -> BudgetPlan:
         """Create a budget plan for the given DataFrame.
 
@@ -82,6 +83,8 @@ class TokenBudgetAllocator:
             Whether stats section is enabled.
         include_samples : bool
             Whether samples section is enabled.
+        column_priority : dict[str, float] or None
+            Explicit weight multipliers per column.
 
         Returns
         -------
@@ -119,7 +122,7 @@ class TokenBudgetAllocator:
         # Distribute stats budget across columns
         columns = list(df.columns)
         column_budgets = _distribute_column_budget(
-            df, columns, stats_budget, hint
+            df, columns, stats_budget, hint, column_priority
         )
 
         return BudgetPlan(
@@ -135,6 +138,7 @@ def _distribute_column_budget(
     columns: Sequence[object],
     stats_budget: int,
     hint: str | None,
+    column_priority: dict[str, float] | None = None,
 ) -> dict[str, int]:
     """Distribute stats budget across columns.
 
@@ -142,12 +146,14 @@ def _distribute_column_budget(
     ----------
     df : pd.DataFrame
         The DataFrame.
-    columns : list[str]
+    columns : Sequence[object]
         Column names to distribute budget across.
     stats_budget : int
         Total stats budget to distribute.
     hint : str or None
         Query hint for boosting relevant columns.
+    column_priority : dict[str, float] or None
+        Explicit weight multipliers per column.
 
     Returns
     -------
@@ -186,6 +192,13 @@ def _distribute_column_budget(
             )
             if relevance > 0:
                 weights[col] *= 1.0 + relevance * 2.0
+
+    # Apply explicit column priority
+    if column_priority:
+        for col in columns:
+            col_str = str(col)
+            if col_str in column_priority:
+                weights[col] *= column_priority[col_str]
 
     # Normalize and allocate
     total_weight = sum(weights.values())

--- a/src/dfcontext/config.py
+++ b/src/dfcontext/config.py
@@ -49,6 +49,7 @@ class ContextConfig:
     include_samples: bool = True
     max_sample_rows: int = 5
     include_correlations: bool = False
+    column_priority: dict[str, float] | None = None
     tokenizer: str = "cl100k_base"
     budget_ratio: dict[str, float] = field(
         default_factory=lambda: dict(_DEFAULT_BUDGET_RATIO)

--- a/src/dfcontext/core.py
+++ b/src/dfcontext/core.py
@@ -51,6 +51,7 @@ def to_context(
     max_sample_rows: int = 5,
     columns: list[str] | None = None,
     exclude_columns: list[str] | None = None,
+    column_priority: dict[str, float] | None = None,
     tokenizer: str = "cl100k_base",
     config: ContextConfig | None = None,
 ) -> str:
@@ -80,6 +81,8 @@ def to_context(
         Subset of columns to include. ``None`` means all.
     exclude_columns : list[str] or None
         Columns to exclude (e.g. sensitive data). Applied after ``columns``.
+    column_priority : dict[str, float] or None
+        Explicit weight multipliers per column for budget allocation.
     tokenizer : str
         tiktoken encoding name.
     config : ContextConfig or None
@@ -103,6 +106,7 @@ def to_context(
             include_samples=include_samples,
             include_correlations=include_correlations,
             max_sample_rows=max_sample_rows,
+            column_priority=column_priority,
             tokenizer=tokenizer,
         )
 
@@ -129,6 +133,7 @@ def to_context(
         include_schema=cfg.include_schema,
         include_stats=cfg.include_stats,
         include_samples=cfg.include_samples,
+        column_priority=cfg.column_priority,
     )
 
     parts: list[str] = []

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -119,6 +119,21 @@ class TestTokenBudgetAllocator:
         total_col_budget = sum(plan.column_budgets.values())
         assert total_col_budget <= 100
 
+    def test_column_priority_boosts(self) -> None:
+        df = pd.DataFrame({
+            "important": range(100),
+            "normal": range(100),
+            "minor": range(100),
+        })
+        allocator = TokenBudgetAllocator()
+        plan = allocator.allocate(
+            df,
+            total_budget=1000,
+            column_priority={"important": 5.0, "minor": 0.1},
+        )
+        assert plan.column_budgets["important"] > plan.column_budgets["normal"]
+        assert plan.column_budgets["normal"] > plan.column_budgets["minor"]
+
     def test_integer_column_names(self) -> None:
         df = pd.DataFrame({0: [1, 2], 1: [3, 4], 2: [5, 6]})
         allocator = TokenBudgetAllocator()


### PR DESCRIPTION
## Summary

New `column_priority` parameter in `to_context()` and `ContextConfig`. Users can specify explicit weight multipliers per column (e.g. `{"sales": 5.0, "id": 0.1}`), applied on top of automatic weighting.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)