### PR TITLE
feat: Add compare_contexts() for DataFrame comparison

### DIFF
--- a/src/dfcontext/__init__.py
+++ b/src/dfcontext/__init__.py
@@ -4,7 +4,12 @@ from dfcontext._version import __version__
 from dfcontext.analyzers.base import ColumnSummary
 from dfcontext.budget import BudgetPlan
 from dfcontext.config import ContextConfig
-from dfcontext.core import analyze_columns, count_tokens, to_context
+from dfcontext.core import (
+    analyze_columns,
+    compare_contexts,
+    count_tokens,
+    to_context,
+)
 
 __all__ = [
     "BudgetPlan",
@@ -12,6 +17,7 @@ __all__ = [
     "ContextConfig",
     "__version__",
     "analyze_columns",
+    "compare_contexts",
     "count_tokens",
     "to_context",
 ]

--- a/src/dfcontext/core.py
+++ b/src/dfcontext/core.py
@@ -242,6 +242,48 @@ def count_tokens(
     return tc.count(text)
 
 
+def compare_contexts(
+    df_a: pd.DataFrame,
+    df_b: pd.DataFrame,
+    label_a: str = "Dataset A",
+    label_b: str = "Dataset B",
+    token_budget: int = 2000,
+    hint: str | None = None,
+    **kwargs: object,
+) -> str:
+    """Generate a comparison context from two DataFrames.
+
+    Splits the token budget evenly and produces a side-by-side summary.
+
+    Parameters
+    ----------
+    df_a : pd.DataFrame
+        First DataFrame.
+    df_b : pd.DataFrame
+        Second DataFrame.
+    label_a : str
+        Label for the first dataset.
+    label_b : str
+        Label for the second dataset.
+    token_budget : int
+        Total token budget (split between both datasets).
+    hint : str or None
+        Query hint applied to both datasets.
+    **kwargs : object
+        Additional keyword arguments passed to ``to_context()``.
+
+    Returns
+    -------
+    str
+        Combined context string for comparison.
+
+    """
+    per_dataset = token_budget // 2
+    ctx_a = to_context(df_a, token_budget=per_dataset, hint=hint, **kwargs)  # type: ignore[arg-type]
+    ctx_b = to_context(df_b, token_budget=per_dataset, hint=hint, **kwargs)  # type: ignore[arg-type]
+    return f"## {label_a}\n{ctx_a}\n\n## {label_b}\n{ctx_b}"
+
+
 def _analyze_all_columns(
     df: pd.DataFrame,
     column_budgets: dict[str, int],

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,41 @@
+"""Tests for compare_contexts."""
+
+import numpy as np
+import pandas as pd
+
+from dfcontext import compare_contexts, count_tokens
+
+
+class TestCompareContexts:
+    def test_basic_comparison(self) -> None:
+        df_a = pd.DataFrame({"x": range(50)})
+        df_b = pd.DataFrame({"x": range(100)})
+        result = compare_contexts(df_a, df_b)
+
+        assert "## Dataset A" in result
+        assert "## Dataset B" in result
+        assert "50 rows" in result
+        assert "100 rows" in result
+
+    def test_custom_labels(self) -> None:
+        df_a = pd.DataFrame({"x": [1]})
+        df_b = pd.DataFrame({"x": [2]})
+        result = compare_contexts(
+            df_a, df_b, label_a="2023", label_b="2024"
+        )
+        assert "## 2023" in result
+        assert "## 2024" in result
+
+    def test_budget_split(self) -> None:
+        np.random.seed(42)
+        df_a = pd.DataFrame({f"c{i}": range(100) for i in range(10)})
+        df_b = pd.DataFrame({f"c{i}": range(100) for i in range(10)})
+        result = compare_contexts(df_a, df_b, token_budget=1000)
+        tokens = count_tokens(result)
+        assert tokens <= 1100  # some overhead from labels
+
+    def test_with_hint(self) -> None:
+        df_a = pd.DataFrame({"sales": [100], "id": [1]})
+        df_b = pd.DataFrame({"sales": [200], "id": [2]})
+        result = compare_contexts(df_a, df_b, hint="sales")
+        assert "sales" in result


### PR DESCRIPTION
## Summary

New `compare_contexts(df_a, df_b)` public API that splits token budget and produces labeled side-by-side comparison context.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)